### PR TITLE
Revert base unit to bytes, with proper cast and bit-byte conversion.

### DIFF
--- a/homeplug_exporter.go
+++ b/homeplug_exporter.go
@@ -54,12 +54,12 @@ func NewExporter(iface *net.Interface, conn *raw.Conn, dest net.HardwareAddr) *E
     conn:   conn,
     dest:   dest,
     txRate: prometheus.NewDesc(
-      prometheus.BuildFQName(namespace, "station", "tx_rate_megabits"),
+      prometheus.BuildFQName(namespace, "station", "tx_rate_bytes"),
       "Average PHY Tx data rate",
       []string{"mac_address", "terminal_equipment_identifier"},
       nil),
     rxRate: prometheus.NewDesc(
-      prometheus.BuildFQName(namespace, "station", "rx_rate_megabits"),
+      prometheus.BuildFQName(namespace, "station", "rx_rate_bytes"),
       "Average PHY Rx data rate",
       []string{"mac_address", "terminal_equipment_identifier"},
       nil),
@@ -100,9 +100,9 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) error {
 
     for _, station := range info.Stations {
       ch <- prometheus.MustNewConstMetric(e.txRate, prometheus.GaugeValue,
-            float64(station.TxRate), station.Address.String(), strconv.FormatInt(int64(station.TEI), 10))
+            float64(uint64(station.TxRate) * 1024 * 1024 / 8), station.Address.String(), strconv.FormatInt(int64(station.TEI), 10))
       ch <- prometheus.MustNewConstMetric(e.rxRate, prometheus.GaugeValue,
-            float64(station.RxRate), station.Address.String(), strconv.FormatInt(int64(station.TEI), 10))
+            float64(uint64(station.RxRate) * 1024 * 1024 / 8), station.Address.String(), strconv.FormatInt(int64(station.TEI), 10))
     }
   }
   return nil


### PR DESCRIPTION
Closes: #2 

As discussed in the bug report, sending my patch. This seems to work fine for me:
```
$ plcstat -i br-lan -t
 P/L NET TEI ------ MAC ------ ------ BDA ------  TX  RX CHIPSET FIRMWARE
 LOC STA 002 E8:DE:27:34:99:73 14:CF:92:51:E7:6E n/a n/a QCA6410 MAC-QCA6410-1.1.0.846-02-20121116-FINAL
 REM CCO 001 E8:DE:27:34:94:44 54:83:3A:C5:F9:70 082 079 QCA6410 MAC-QCA6410-1.1.0.846-02-20121116-FINAL

$ curl -s http://localhost:9702/metrics | grep ^homeplug_station_
homeplug_station_rx_rate_bytes{mac_address="e8:de:27:34:94:44",terminal_equipment_identifier="1"} 1.0354688e+07
homeplug_station_rx_rate_bytes{mac_address="e8:de:27:34:99:73",terminal_equipment_identifier="2"} 1.0747904e+07

```