### PR TITLE
Migrate logging to go-kit/log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,27 @@
 module github.com/brandond/homeplug_exporter
 
-go 1.14
+go 1.18
 
 require (
+	github.com/go-kit/log v0.2.0
 	github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7
 	github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065
-	github.com/prometheus/client_golang v1.0.0
-	github.com/prometheus/common v0.9.1
+	github.com/prometheus/client_golang v1.13.0
+	github.com/prometheus/common v0.37.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+)
+
+require (
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/go-logfmt/logfmt v0.5.1 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/procfs v0.8.0 // indirect
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
 )


### PR DESCRIPTION
Since the prometheus/common package no longer provides a wrapper for logrus, and the majority of other Prometheus exporters have migrated to go-kit/log, it makes sense to do so here also.

Bump go.mod Go version to oldest supported version (1.18, as of writing), and update both prometheus/common and prometheus/client_golang dependencies.

Signed-off-by: Daniel Swarbrick <dswarbrick@debian.org>